### PR TITLE
workflows: add manual dispatch triggers

### DIFF
--- a/.github/workflows/cache-guard.yml
+++ b/.github/workflows/cache-guard.yml
@@ -1,6 +1,7 @@
 name: Prevent Simulation Cache Layer Commits
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'test/simulation/cache/layers/**'
@@ -14,5 +15,9 @@ jobs:
     steps:
       - name: Block cache layer changes
         run: |
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+            echo "Manual run: no cache layer changes to block."
+            exit 0
+          fi
           echo "Simulation cache layers must not be pushed. Fetch the cache from upstream instead."
           exit 1

--- a/.github/workflows/ensure-node-modules-cache.yml
+++ b/.github/workflows/ensure-node-modules-cache.yml
@@ -1,6 +1,7 @@
 name: Ensure node modules cache
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,7 @@
 name: PR Checks
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'gh-readonly-queue/main/*'


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to allow manual triggering of workflows and improves the handling of manual runs for the cache guard workflow. The main changes are focused on workflow configuration and developer experience.

**Workflow trigger improvements:**

* Added the `workflow_dispatch` trigger to `.github/workflows/cache-guard.yml`, `.github/workflows/ensure-node-modules-cache.yml`, and `.github/workflows/pr.yml` to allow these workflows to be run manually from the GitHub Actions UI. [[1]](diffhunk://#diff-74aebf6f59c4168f37d5b5b12e260534c57c424427bc872125821e6235159d25R4) [[2]](diffhunk://#diff-e65f21e02782f7475c89a8bce2bf0fccf7cf069a25ee2c3a8baa2295fb46194bR4) [[3]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160R4)

**Cache guard workflow logic:**

* Updated the "Block cache layer changes" step in `.github/workflows/cache-guard.yml` to detect manual workflow runs and skip blocking logic when triggered via `workflow_dispatch`, providing a clear message and exiting successfully.