### PR TITLE
endpoint: fix responses api typings

### DIFF
--- a/.github/workflows/cache-guard.yml
+++ b/.github/workflows/cache-guard.yml
@@ -1,6 +1,7 @@
 name: Prevent Simulation Cache Layer Commits
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'test/simulation/cache/layers/**'
@@ -13,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Block cache layer changes
+        shell: bash
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual run for validation only. No cache layer changes to block."
+            exit 0
+          fi
+
           echo "Simulation cache layers must not be pushed. Fetch the cache from upstream instead."
           exit 1

--- a/.github/workflows/fork-nightly-merge.yml
+++ b/.github/workflows/fork-nightly-merge.yml
@@ -62,6 +62,10 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     environment: develop
+    env:
+      MERGE_LOG_PATH: ''
+      PR_URL: ''
+      SYNC_OUTCOME: ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -94,27 +98,35 @@ jobs:
 
       - name: Append job summary
         if: always()
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          TARGET_BRANCH: ${{ inputs.target_branch || 'main' }}
+          SYNC_BRANCH: ${{ inputs.sync_branch || 'automation/nightly-upstream-merge' }}
+          UPSTREAM_REPO: ${{ inputs.upstream_repo || 'microsoft/vscode-copilot-chat' }}
+          UPSTREAM_BRANCH: ${{ inputs.upstream_branch || 'main' }}
+          TRIGGER_REF: ${{ github.ref }}
         run: |
           {
             echo "### Fork Nightly Merge"
             echo ""
-            if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            if [ "${DRY_RUN}" = "true" ]; then
               echo "⚠️ **Dry run mode**: This was a test run, no PR was created."
               echo ""
             fi
             echo "**Configuration:**"
-            echo "* Target branch: ${{ inputs.target_branch || 'main' }}"
-            echo "* Sync branch: ${{ inputs.sync_branch || 'automation/nightly-upstream-merge' }}"
-            echo "* Upstream repo: ${{ inputs.upstream_repo || 'microsoft/vscode-copilot-chat' }}"
-            echo "* Upstream branch: ${{ inputs.upstream_branch || 'main' }}"
-            echo "* Triggered from: ${{ github.ref }}"
+            echo "* Target branch: ${TARGET_BRANCH}"
+            echo "* Sync branch: ${SYNC_BRANCH}"
+            echo "* Upstream repo: ${UPSTREAM_REPO}"
+            echo "* Upstream branch: ${UPSTREAM_BRANCH}"
+            echo "* Triggered from: ${TRIGGER_REF}"
             echo ""
             echo "**Result:**"
             echo "* Outcome: ${SYNC_OUTCOME:-unknown}"
-            if [[ -n "${PR_URL:-}" ]]; then
+            if [ -n "${PR_URL:-}" ]; then
               echo "* PR: ${PR_URL}"
             fi
-            if [[ -n "${MERGE_LOG_PATH:-}" ]]; then
+            if [ -n "${MERGE_LOG_PATH:-}" ]; then
               echo "* Merge log: ${MERGE_LOG_PATH}"
             fi
           } >>"$GITHUB_STEP_SUMMARY"

--- a/src/platform/endpoint/node/responsesApi.ts
+++ b/src/platform/endpoint/node/responsesApi.ts
@@ -336,11 +336,34 @@ function responseOutputToRawContent(part: OpenAI.Responses.ResponseOutputText | 
 	}
 }
 
-function responseFunctionOutputToRawContents(output: string | ReadonlyArray<OpenAI.Responses.ResponseInputContent>): Raw.ChatCompletionContentPart[] {
+type ResponseFunctionOutputItem = OpenAI.Responses.ResponseFunctionCallOutputItem | OpenAI.Responses.ResponseInputContent;
+
+function responseFunctionOutputToRawContents(output: string | ReadonlyArray<ResponseFunctionOutputItem>): Raw.ChatCompletionContentPart[] {
 	if (typeof output === 'string') {
 		return [{ type: Raw.ChatCompletionContentPartKind.Text, text: output }];
 	}
-	return coalesce(output.map(responseContentToRawContent));
+	return coalesce(output.map(normalizeFunctionCallOutputItem).map(responseContentToRawContent));
+}
+
+function normalizeFunctionCallOutputItem(item: ResponseFunctionOutputItem): OpenAI.Responses.ResponseInputContent {
+	if (item.type === 'input_image') {
+		return {
+			type: 'input_image',
+			detail: item.detail ?? 'auto',
+			file_id: item.file_id,
+			image_url: item.image_url
+		};
+	}
+	if (item.type === 'input_file') {
+		return {
+			type: 'input_file',
+			file_data: item.file_data ?? undefined,
+			file_id: item.file_id ?? undefined,
+			file_url: item.file_url ?? undefined,
+			filename: item.filename ?? undefined,
+		};
+	}
+	return item;
 }
 
 export async function processResponseFromChatEndpoint(instantiationService: IInstantiationService, telemetryService: ITelemetryService, logService: ILogService, response: Response, expectedNumChoices: number, finishCallback: FinishedCallback, telemetryData: TelemetryData): Promise<AsyncIterableObject<ChatCompletion>> {


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across GitHub Actions workflows and the Node responses API. The most notable changes include enhanced shell compatibility and environment handling in workflow scripts, as well as improved normalization of function call outputs in the API layer.

**GitHub Actions workflow improvements:**

* Standardized the shell to `bash` and improved string comparison for better cross-shell compatibility in `.github/workflows/cache-guard.yml` and `.github/workflows/fork-nightly-merge.yml` [[1]](diffhunk://#diff-74aebf6f59c4168f37d5b5b12e260534c57c424427bc872125821e6235159d25R17-R23) [[2]](diffhunk://#diff-f8134550bc6bba7da478dc341b2e254d21c9908e9367b1fc54e64be447b37b8dR101-R129).
* Added explicit environment variable initialization at the start of the `merge` job in `.github/workflows/fork-nightly-merge.yml` to prevent unbound variable errors and improve script robustness.
* Updated the summary step in `.github/workflows/fork-nightly-merge.yml` to use environment variables instead of GitHub Actions expressions, ensuring accurate and consistent reporting of configuration and results.

**Node responses API enhancements:**

* Introduced a new `ResponseFunctionOutputItem` type and a `normalizeFunctionCallOutputItem` helper in `src/platform/endpoint/node/responsesApi.ts` to ensure consistent normalization of function call output items, improving downstream processing reliability.